### PR TITLE
forgot to expect submitBtn to be in the document

### DIFF
--- a/src/Tests/DisplayOptionsForm.test.js
+++ b/src/Tests/DisplayOptionsForm.test.js
@@ -29,4 +29,5 @@ test("[2] Submit Button appears in document", () => {
   render(<DisplayOptionsForm />);
 
   const submitBtn = screen.getByTestId("form-submit-button");
+  expect(submitBtn).toBeInTheDocument();
 });


### PR DESCRIPTION
Very small PR: in DisplayFormOptionsForm.test, forgot to expect submitBtn to be in the document