### PR TITLE
Display pokemon option - Adding it to redux state

### DIFF
--- a/src/Components/DisplayOptionsForm.js
+++ b/src/Components/DisplayOptionsForm.js
@@ -9,6 +9,7 @@ const selectState = (state) => state;
 const DisplayOptionsForm = (props) => {
   const stateValues = useSelector(selectState);
 
+  //updates any time a form input is changed (before hitting submit)
   const [formValues, setFormValues] = useState(stateValues);
 
   const dispatch = useDispatch();

--- a/src/Components/DisplayOptionsForm.js
+++ b/src/Components/DisplayOptionsForm.js
@@ -78,26 +78,33 @@ const DisplayOptionsForm = (props) => {
         ></StyInput>
       </div>
 
-      {/* <div>
+      <div>
         <StyLabel
-          htmlFor="quantity"
-          value={formValues.limit}
-          data-testid="display-limit-label"
+          htmlFor="checkbox"
+          // value={formValues.displayPokemon.isDisplayPokemon}
         >
-          Limit:
+          Display Pokemon:
         </StyLabel>
         <StyInput
-          type="number"
-          name="limit"
-          value={formValues.limit}
+          type="checkbox"
+          name="checkbox"
+          value={formValues.displayPokemon.isDisplayPokemon}
           onChange={(e) => {
-            setFormValues({ ...formValues, limit: Number(e.target.value) });
+            setFormValues({
+              ...formValues,
+              displayPokemon: {
+                // isDisplayPokemon: !formValues.displayPokemon.isDisplayPokemon;
+                isDisplayPokemon: !e.target.checked,
+              },
+            });
+            // console.log("e.target.checked:", e.target.checked);
+            console.log(
+              "isDisplayPokemon:",
+              formValues.displayPokemon.isDisplayPokemon
+            );
           }}
-          data-testid="display-limit-input"
-          min={1}
-          max={300}
         ></StyInput>
-      </div> */}
+      </div>
 
       <div>
         <StyInput type="submit" data-testid="form-submit-button"></StyInput>

--- a/src/Components/DisplayOptionsForm.js
+++ b/src/Components/DisplayOptionsForm.js
@@ -36,7 +36,6 @@ const DisplayOptionsForm = (props) => {
           name="multiplier"
           value={formValues.tableValues.multiplier}
           onChange={(e) => {
-            e.preventDefault();
             setFormValues({
               ...formValues,
               tableValues: {
@@ -62,7 +61,6 @@ const DisplayOptionsForm = (props) => {
           name="limit"
           value={formValues.tableValues.limit}
           onChange={(e) => {
-            e.preventDefault();
             setFormValues({
               ...formValues,
               tableValues: {

--- a/src/Components/DisplayOptionsForm.js
+++ b/src/Components/DisplayOptionsForm.js
@@ -24,6 +24,10 @@ const DisplayOptionsForm = (props) => {
       type: "NEWMULTIPLIERANDLIMIT",
       payload: formValues.tableValues,
     });
+    dispatch({
+      type: "TOGGLEPOKEMONDISPLAYOPTION",
+      payload: formValues.displayPokemon.isDisplayPokemon,
+    });
   };
 
   return (
@@ -94,14 +98,14 @@ const DisplayOptionsForm = (props) => {
               ...formValues,
               displayPokemon: {
                 // isDisplayPokemon: !formValues.displayPokemon.isDisplayPokemon;
-                isDisplayPokemon: !e.target.checked,
+                isDisplayPokemon: e.target.checked,
               },
             });
             // console.log("e.target.checked:", e.target.checked);
-            console.log(
-              "isDisplayPokemon:",
-              formValues.displayPokemon.isDisplayPokemon
-            );
+            // console.log(
+            //   "isDisplayPokemon:",
+            //   formValues.displayPokemon.isDisplayPokemon
+            // );
           }}
         ></StyInput>
       </div>

--- a/src/Components/DisplayOptionsForm.js
+++ b/src/Components/DisplayOptionsForm.js
@@ -16,6 +16,7 @@ const DisplayOptionsForm = (props) => {
   const dispatch = useDispatch();
 
   const onSubmit = (e) => {
+    //updates Redux global state with new multiplier, limit and displayPokemon boolean based on user preferences
     e.preventDefault();
     dispatch({
       type: "NEWMULTIPLIERANDLIMIT",

--- a/src/Components/DisplayOptionsForm.js
+++ b/src/Components/DisplayOptionsForm.js
@@ -2,8 +2,8 @@ import styled from "styled-components";
 //useDispatch lets us update global state (through redux) with actions
 import { useDispatch } from "react-redux";
 import { useState } from "react";
-
 import { useSelector } from "react-redux";
+
 const selectState = (state) => state;
 
 const DisplayOptionsForm = (props) => {

--- a/src/Components/DisplayOptionsForm.js
+++ b/src/Components/DisplayOptionsForm.js
@@ -81,12 +81,7 @@ const DisplayOptionsForm = (props) => {
       </div>
 
       <div>
-        <StyLabel
-          htmlFor="checkbox"
-          // value={formValues.displayPokemon.isDisplayPokemon}
-        >
-          Display Pokemon:
-        </StyLabel>
+        <StyLabel htmlFor="checkbox">Display Pokemon:</StyLabel>
         <StyInput
           type="checkbox"
           name="checkbox"
@@ -95,7 +90,6 @@ const DisplayOptionsForm = (props) => {
             setFormValues({
               ...formValues,
               displayPokemon: {
-                // isDisplayPokemon: !formValues.displayPokemon.isDisplayPokemon;
                 isDisplayPokemon: e.target.checked,
               },
             });

--- a/src/Components/DisplayOptionsForm.js
+++ b/src/Components/DisplayOptionsForm.js
@@ -3,6 +3,8 @@ import styled from "styled-components";
 import { useDispatch } from "react-redux";
 import { useState } from "react";
 
+//TODO: Put pokemon display toggle option in here, dispatch that on submit, make it toggle pokemon pictures
+
 const DisplayOptionsForm = (props) => {
   const [formValues, setFormValues] = useState({ multiplier: 0, limit: 0 });
 

--- a/src/Components/DisplayOptionsForm.js
+++ b/src/Components/DisplayOptionsForm.js
@@ -74,7 +74,7 @@ const DisplayOptionsForm = (props) => {
           }}
           data-testid="display-limit-input"
           min={1}
-          max={300}
+          max={100}
         ></StyInput>
       </div>
 

--- a/src/Components/DisplayOptionsForm.js
+++ b/src/Components/DisplayOptionsForm.js
@@ -2,7 +2,7 @@ import styled from "styled-components";
 //useDispatch lets us update global state (through redux) with actions
 import { useDispatch } from "react-redux";
 import { useState } from "react";
-
+import { useSelector } from "react-redux";
 //TODO: Put pokemon display toggle option in here, dispatch that on submit, make it toggle pokemon pictures
 
 const DisplayOptionsForm = (props) => {

--- a/src/Components/DisplayOptionsForm.js
+++ b/src/Components/DisplayOptionsForm.js
@@ -11,17 +11,18 @@ const DisplayOptionsForm = (props) => {
   const stateValues = useSelector(selectState);
   console.log("stateValues:", stateValues);
 
-  const [formValues, setFormValues] = useState({ multiplier: 0, limit: 0 });
+  const [formValues, setFormValues] = useState(stateValues);
 
   const dispatch = useDispatch();
 
   const onSubmit = (e) => {
+    console.log("formValues:", formValues);
     //doing preventDefault leaves the user-submitted values in the form fields,
     //which is good so they can remember their inputs.
     e.preventDefault();
     dispatch({
       type: "NEWMULTIPLIERANDLIMIT",
-      payload: formValues,
+      payload: formValues.tableValues,
     });
   };
 
@@ -34,11 +35,15 @@ const DisplayOptionsForm = (props) => {
         <StyInput
           type="number"
           name="multiplier"
-          value={formValues.multiplier}
+          value={formValues.tableValues.multiplier}
           onChange={(e) => {
+            e.preventDefault();
             setFormValues({
               ...formValues,
-              multiplier: Number(e.target.value),
+              tableValues: {
+                limit: formValues.tableValues.limit,
+                multiplier: Number(e.target.value),
+              },
             });
           }}
           data-testid="multiplier-input"
@@ -48,7 +53,7 @@ const DisplayOptionsForm = (props) => {
       <div>
         <StyLabel
           htmlFor="quantity"
-          value={formValues.limit}
+          value={formValues.tableValues.limit}
           data-testid="display-limit-label"
         >
           Limit:
@@ -56,9 +61,16 @@ const DisplayOptionsForm = (props) => {
         <StyInput
           type="number"
           name="limit"
-          value={formValues.limit}
+          value={formValues.tableValues.limit}
           onChange={(e) => {
-            setFormValues({ ...formValues, limit: Number(e.target.value) });
+            e.preventDefault();
+            setFormValues({
+              ...formValues,
+              tableValues: {
+                multiplier: formValues.tableValues.multiplier,
+                limit: Number(e.target.value),
+              },
+            });
           }}
           data-testid="display-limit-input"
           min={1}

--- a/src/Components/DisplayOptionsForm.js
+++ b/src/Components/DisplayOptionsForm.js
@@ -2,10 +2,15 @@ import styled from "styled-components";
 //useDispatch lets us update global state (through redux) with actions
 import { useDispatch } from "react-redux";
 import { useState } from "react";
+
 import { useSelector } from "react-redux";
+const selectState = (state) => state;
 //TODO: Put pokemon display toggle option in here, dispatch that on submit, make it toggle pokemon pictures
 
 const DisplayOptionsForm = (props) => {
+  const stateValues = useSelector(selectState);
+  console.log("stateValues:", stateValues);
+
   const [formValues, setFormValues] = useState({ multiplier: 0, limit: 0 });
 
   const dispatch = useDispatch();

--- a/src/Components/DisplayOptionsForm.js
+++ b/src/Components/DisplayOptionsForm.js
@@ -61,6 +61,27 @@ const DisplayOptionsForm = (props) => {
         ></StyInput>
       </div>
 
+      {/* <div>
+        <StyLabel
+          htmlFor="quantity"
+          value={formValues.limit}
+          data-testid="display-limit-label"
+        >
+          Limit:
+        </StyLabel>
+        <StyInput
+          type="number"
+          name="limit"
+          value={formValues.limit}
+          onChange={(e) => {
+            setFormValues({ ...formValues, limit: Number(e.target.value) });
+          }}
+          data-testid="display-limit-input"
+          min={1}
+          max={300}
+        ></StyInput>
+      </div> */}
+
       <div>
         <StyInput type="submit" data-testid="form-submit-button"></StyInput>
       </div>

--- a/src/Components/DisplayOptionsForm.js
+++ b/src/Components/DisplayOptionsForm.js
@@ -5,7 +5,6 @@ import { useState } from "react";
 
 import { useSelector } from "react-redux";
 const selectState = (state) => state;
-//TODO: Put pokemon display toggle option in here, dispatch that on submit, make it toggle pokemon pictures
 
 const DisplayOptionsForm = (props) => {
   const stateValues = useSelector(selectState);
@@ -15,8 +14,6 @@ const DisplayOptionsForm = (props) => {
   const dispatch = useDispatch();
 
   const onSubmit = (e) => {
-    //doing preventDefault leaves the user-submitted values in the form fields,
-    //which is good so they can remember their inputs.
     e.preventDefault();
     dispatch({
       type: "NEWMULTIPLIERANDLIMIT",

--- a/src/Components/DisplayOptionsForm.js
+++ b/src/Components/DisplayOptionsForm.js
@@ -9,14 +9,12 @@ const selectState = (state) => state;
 
 const DisplayOptionsForm = (props) => {
   const stateValues = useSelector(selectState);
-  console.log("stateValues:", stateValues);
 
   const [formValues, setFormValues] = useState(stateValues);
 
   const dispatch = useDispatch();
 
   const onSubmit = (e) => {
-    console.log("formValues:", formValues);
     //doing preventDefault leaves the user-submitted values in the form fields,
     //which is good so they can remember their inputs.
     e.preventDefault();
@@ -101,11 +99,6 @@ const DisplayOptionsForm = (props) => {
                 isDisplayPokemon: e.target.checked,
               },
             });
-            // console.log("e.target.checked:", e.target.checked);
-            // console.log(
-            //   "isDisplayPokemon:",
-            //   formValues.displayPokemon.isDisplayPokemon
-            // );
           }}
         ></StyInput>
       </div>

--- a/src/Components/DisplayOptionsForm.js
+++ b/src/Components/DisplayOptionsForm.js
@@ -40,7 +40,7 @@ const DisplayOptionsForm = (props) => {
             setFormValues({
               ...formValues,
               tableValues: {
-                limit: formValues.tableValues.limit,
+                ...formValues.tableValues,
                 multiplier: Number(e.target.value),
               },
             });
@@ -66,7 +66,7 @@ const DisplayOptionsForm = (props) => {
             setFormValues({
               ...formValues,
               tableValues: {
-                multiplier: formValues.tableValues.multiplier,
+                ...formValues.tableValues,
                 limit: Number(e.target.value),
               },
             });

--- a/src/Components/DisplayOptionsForm.js
+++ b/src/Components/DisplayOptionsForm.js
@@ -7,6 +7,7 @@ import { useSelector } from "react-redux";
 const selectState = (state) => state;
 
 const DisplayOptionsForm = (props) => {
+  //stateValues is pulled from redux state store
   const stateValues = useSelector(selectState);
 
   //updates any time a form input is changed (before hitting submit)

--- a/src/Components/MultTableContainer.js
+++ b/src/Components/MultTableContainer.js
@@ -5,6 +5,7 @@ import { useSelector } from "react-redux";
 const selectState = (state) => state;
 
 const MultTableContainer = (props) => {
+  //pulls in global state from Redux store
   const state = useSelector(selectState);
   const { multiplier, limit } = state.tableValues;
 

--- a/src/Components/MultTableContainer.js
+++ b/src/Components/MultTableContainer.js
@@ -14,18 +14,14 @@ const MultTableContainer = (props) => {
   console.log("MTC tableValues:", tableValues);
 
   const multiplier = tableValues.multiplier;
-  // const maxDisplayed = new Array(tableValues.limit);
 
-  //making an array that the mult table generator will map over
-  // for (let i = 0; i < maxDisplayed.length; i++) {
-  //   maxDisplayed[i] = (i + 1) * multiplier;
-  // }
-
+  //creating an array to map over to generate multiplication table
+  //it's just full of zeroes, it could contain anything, doesn't matter. I just can't map over a sparse array,
+  //so I had to fill it with something.
   const tableItemsArray = Array(tableValues.limit).fill(0);
 
   return (
     <StyledTableContainer>
-      {console.log("fdjiaofsda")}
       {tableItemsArray.map((item, index) => {
         return (
           <SingleTableItem

--- a/src/Components/MultTableContainer.js
+++ b/src/Components/MultTableContainer.js
@@ -2,23 +2,16 @@ import styled from "styled-components";
 import SingleTableItem from "./SingleTableItem";
 //useSelector replaces a subscribe function; it knows when state updates and updates components if needed
 import { useSelector } from "react-redux";
-const selectTableValues = (state) => state.tableValues;
-const selectDisplayPokemon = (state) => {
-  return state.displayPokemon.isDisplayPokemon;
-};
+const selectState = (state) => state;
+
 const MultTableContainer = (props) => {
-  const tableValues = useSelector(selectTableValues);
-  const displayPokemon = useSelector(selectDisplayPokemon);
-
-  console.log("MTC displayPokemon:", displayPokemon);
-  console.log("MTC tableValues:", tableValues);
-
-  const multiplier = tableValues.multiplier;
+  const state = useSelector(selectState);
+  const { multiplier, limit } = state.tableValues;
 
   //creating an array to map over to generate multiplication table
   //it's just full of zeroes, it could contain anything, doesn't matter. I just can't map over a sparse array,
   //so I had to fill it with something.
-  const tableItemsArray = Array(tableValues.limit).fill(0);
+  const tableItemsArray = Array(limit).fill(0);
 
   return (
     <StyledTableContainer>

--- a/src/Components/MultTableContainer.js
+++ b/src/Components/MultTableContainer.js
@@ -14,19 +14,22 @@ const MultTableContainer = (props) => {
   console.log("MTC tableValues:", tableValues);
 
   const multiplier = tableValues.multiplier;
-  const maxDisplayed = new Array(tableValues.limit);
+  // const maxDisplayed = new Array(tableValues.limit);
 
   //making an array that the mult table generator will map over
-  for (let i = 0; i < maxDisplayed.length; i++) {
-    maxDisplayed[i] = (i + 1) * multiplier;
-  }
+  // for (let i = 0; i < maxDisplayed.length; i++) {
+  //   maxDisplayed[i] = (i + 1) * multiplier;
+  // }
+
+  const tableItemsArray = Array(tableValues.limit).fill(0);
 
   return (
     <StyledTableContainer>
-      {maxDisplayed.map((item, index) => {
+      {console.log("fdjiaofsda")}
+      {tableItemsArray.map((item, index) => {
         return (
           <SingleTableItem
-            key={item}
+            key={index}
             toBeMultiplied={multiplier}
             currentMultiplier={index + 1}
           />

--- a/src/Components/MultTableContainer.js
+++ b/src/Components/MultTableContainer.js
@@ -7,6 +7,7 @@ const selectDisplayPokemon = (state) => state.displayPokemon;
 
 const MultTableContainer = (props) => {
   const tableValues = useSelector(selectTableValues);
+  const displayPokemon = useSelector(selectDisplayPokemon);
 
   const multiplier = tableValues.multiplier;
   const maxDisplayed = new Array(tableValues.limit);

--- a/src/Components/MultTableContainer.js
+++ b/src/Components/MultTableContainer.js
@@ -3,13 +3,15 @@ import SingleTableItem from "./SingleTableItem";
 //useSelector replaces a subscribe function; it knows when state updates and updates components if needed
 import { useSelector } from "react-redux";
 const selectTableValues = (state) => state.tableValues;
-const selectDisplayPokemon = (state) => state.displayPokemon.isDisplayPokemon;
-
+const selectDisplayPokemon = (state) => {
+  console.log("MTC State:", state);
+  return state.displayPokemon.isDisplayPokemon;
+};
 const MultTableContainer = (props) => {
   const tableValues = useSelector(selectTableValues);
   const displayPokemon = useSelector(selectDisplayPokemon);
 
-  console.log("tableValues:", tableValues);
+  // console.log("tableValues:", tableValues);
   console.log("displayPokemon:", displayPokemon);
 
   const multiplier = tableValues.multiplier;

--- a/src/Components/MultTableContainer.js
+++ b/src/Components/MultTableContainer.js
@@ -3,6 +3,7 @@ import SingleTableItem from "./SingleTableItem";
 //useSelector replaces a subscribe function; it knows when state updates and updates components if needed
 import { useSelector } from "react-redux";
 const selectTableValues = (state) => state.tableValues;
+const selectDisplayPokemon = (state) => state.displayPokemon;
 
 const MultTableContainer = (props) => {
   const tableValues = useSelector(selectTableValues);

--- a/src/Components/MultTableContainer.js
+++ b/src/Components/MultTableContainer.js
@@ -4,15 +4,11 @@ import SingleTableItem from "./SingleTableItem";
 import { useSelector } from "react-redux";
 const selectTableValues = (state) => state.tableValues;
 const selectDisplayPokemon = (state) => {
-  console.log("MTC State:", state);
   return state.displayPokemon.isDisplayPokemon;
 };
 const MultTableContainer = (props) => {
   const tableValues = useSelector(selectTableValues);
   const displayPokemon = useSelector(selectDisplayPokemon);
-
-  // console.log("tableValues:", tableValues);
-  console.log("displayPokemon:", displayPokemon);
 
   const multiplier = tableValues.multiplier;
   const maxDisplayed = new Array(tableValues.limit);

--- a/src/Components/MultTableContainer.js
+++ b/src/Components/MultTableContainer.js
@@ -10,6 +10,9 @@ const MultTableContainer = (props) => {
   const tableValues = useSelector(selectTableValues);
   const displayPokemon = useSelector(selectDisplayPokemon);
 
+  console.log("MTC displayPokemon:", displayPokemon);
+  console.log("MTC tableValues:", tableValues);
+
   const multiplier = tableValues.multiplier;
   const maxDisplayed = new Array(tableValues.limit);
 

--- a/src/Components/MultTableContainer.js
+++ b/src/Components/MultTableContainer.js
@@ -3,11 +3,14 @@ import SingleTableItem from "./SingleTableItem";
 //useSelector replaces a subscribe function; it knows when state updates and updates components if needed
 import { useSelector } from "react-redux";
 const selectTableValues = (state) => state.tableValues;
-const selectDisplayPokemon = (state) => state.displayPokemon;
+const selectDisplayPokemon = (state) => state.displayPokemon.isDisplayPokemon;
 
 const MultTableContainer = (props) => {
   const tableValues = useSelector(selectTableValues);
   const displayPokemon = useSelector(selectDisplayPokemon);
+
+  console.log("tableValues:", tableValues);
+  console.log("displayPokemon:", displayPokemon);
 
   const multiplier = tableValues.multiplier;
   const maxDisplayed = new Array(tableValues.limit);

--- a/src/Components/SingleTableItem.js
+++ b/src/Components/SingleTableItem.js
@@ -27,11 +27,14 @@ const StySingleTableItem = styled.article`
   padding: 2% auto;
   display: flex;
   flex-direction: column;
-  justify-content: center;
   align-items: center;
-  width: 200px;
+  width: 150px;
+  height: 125px;
+  /* border: 3px solid blue; */
 `;
 
 const StyPokemonFigure = styled.figure`
-  width: 50%;
+  /* width: 50%; */
+  border: 1px solid blue;
+  width: 60%;
 `;

--- a/src/Components/SingleTableItem.js
+++ b/src/Components/SingleTableItem.js
@@ -2,11 +2,11 @@ import styled from "styled-components";
 
 const SingleTableItem = (props) => {
   const { toBeMultiplied, currentMultiplier } = props;
+  const total = toBeMultiplied * currentMultiplier;
 
   return (
     <StySingleTableItem>
-      {toBeMultiplied} x {currentMultiplier} ={" "}
-      {toBeMultiplied * currentMultiplier}
+      {toBeMultiplied} x {currentMultiplier} = {total}
     </StySingleTableItem>
   );
 };

--- a/src/Components/SingleTableItem.js
+++ b/src/Components/SingleTableItem.js
@@ -7,6 +7,15 @@ const SingleTableItem = (props) => {
   return (
     <StySingleTableItem>
       {toBeMultiplied} x {currentMultiplier} = {total}
+      {/* contains pokemon img if user has toggled that option */}
+      <figure>
+        <img
+          className="poke-img"
+          data-testid="shiny"
+          src={`https://www.serebii.net/swordshield/pokemon/${total}.png`}
+          alt="pokemon"
+        />
+      </figure>
     </StySingleTableItem>
   );
 };

--- a/src/Components/SingleTableItem.js
+++ b/src/Components/SingleTableItem.js
@@ -2,7 +2,7 @@ import styled from "styled-components";
 
 const SingleTableItem = (props) => {
   const { toBeMultiplied, currentMultiplier } = props;
-  let total = toBeMultiplied * currentMultiplier;
+  const total = toBeMultiplied * currentMultiplier;
 
   return (
     <StySingleTableItem>

--- a/src/Components/SingleTableItem.js
+++ b/src/Components/SingleTableItem.js
@@ -2,7 +2,8 @@ import styled from "styled-components";
 
 const SingleTableItem = (props) => {
   const { toBeMultiplied, currentMultiplier } = props;
-  const total = toBeMultiplied * currentMultiplier;
+  let total = toBeMultiplied * currentMultiplier;
+  // console.log(makeThreeDigits(total));
 
   return (
     <StySingleTableItem>
@@ -31,3 +32,7 @@ const StySingleTableItem = styled.article`
   justify-content: center;
   width: 200px;
 `;
+
+const makeThreeDigits = (num) => {
+  return Number(String(num).padStart(3, "0"));
+};

--- a/src/Components/SingleTableItem.js
+++ b/src/Components/SingleTableItem.js
@@ -3,7 +3,8 @@ import styled from "styled-components";
 const SingleTableItem = (props) => {
   const { toBeMultiplied, currentMultiplier } = props;
   let total = toBeMultiplied * currentMultiplier;
-  // console.log(makeThreeDigits(total));
+  console.log(makeThreeDigits(total));
+  let pokeId = makeThreeDigits(total);
 
   return (
     <StySingleTableItem>
@@ -11,9 +12,7 @@ const SingleTableItem = (props) => {
       {/* contains pokemon img if user has toggled that option */}
       <figure>
         <img
-          className="poke-img"
-          data-testid="shiny"
-          src={`https://www.serebii.net/swordshield/pokemon/${total}.png`}
+          src={`https://www.serebii.net/swordshield/pokemon/${pokeId}.png`}
           alt="pokemon"
         />
       </figure>
@@ -34,5 +33,8 @@ const StySingleTableItem = styled.article`
 `;
 
 const makeThreeDigits = (num) => {
-  return Number(String(num).padStart(3, "0"));
+  if (num > 99) {
+    return num;
+  }
+  return String(num).padStart(3, "0");
 };

--- a/src/Components/SingleTableItem.js
+++ b/src/Components/SingleTableItem.js
@@ -28,7 +28,9 @@ const StySingleTableItem = styled.article`
   color: black;
   padding: 2% auto;
   display: flex;
+  flex-direction: column;
   justify-content: center;
+  align-items: center;
   width: 200px;
 `;
 

--- a/src/Components/SingleTableItem.js
+++ b/src/Components/SingleTableItem.js
@@ -10,12 +10,12 @@ const SingleTableItem = (props) => {
     <StySingleTableItem>
       {toBeMultiplied} x {currentMultiplier} = {total}
       {/* contains pokemon img if user has toggled that option */}
-      <figure>
+      <StyPokemonFigure>
         <img
           src={`https://www.serebii.net/swordshield/pokemon/${pokeId}.png`}
           alt="pokemon"
         />
-      </figure>
+      </StyPokemonFigure>
     </StySingleTableItem>
   );
 };
@@ -31,6 +31,8 @@ const StySingleTableItem = styled.article`
   justify-content: center;
   width: 200px;
 `;
+
+const StyPokemonFigure = styled.figure``;
 
 //Pokemon ids need to be three digits for img urls,
 //So this converts ids <100 to three digits.

--- a/src/Components/SingleTableItem.js
+++ b/src/Components/SingleTableItem.js
@@ -32,6 +32,8 @@ const StySingleTableItem = styled.article`
   width: 200px;
 `;
 
+//Pokemon ids need to be three digits for img urls,
+//So this converts ids <100 to three digits.
 const makeThreeDigits = (num) => {
   if (num > 99) {
     return num;

--- a/src/Components/SingleTableItem.js
+++ b/src/Components/SingleTableItem.js
@@ -3,8 +3,6 @@ import styled from "styled-components";
 const SingleTableItem = (props) => {
   const { toBeMultiplied, currentMultiplier } = props;
   let total = toBeMultiplied * currentMultiplier;
-  console.log(makeThreeDigits(total));
-  let pokeId = makeThreeDigits(total);
 
   return (
     <StySingleTableItem>
@@ -12,7 +10,7 @@ const SingleTableItem = (props) => {
       {/* contains pokemon img if user has toggled that option */}
       <StyPokemonFigure>
         <img
-          src={`https://www.serebii.net/swordshield/pokemon/${pokeId}.png`}
+          src={`https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/${total}.png`}
           alt="pokemon"
         />
       </StyPokemonFigure>
@@ -34,13 +32,6 @@ const StySingleTableItem = styled.article`
   width: 200px;
 `;
 
-const StyPokemonFigure = styled.figure``;
-
-//Pokemon ids need to be three digits for img urls,
-//So this converts ids <100 to three digits.
-const makeThreeDigits = (num) => {
-  if (num > 99) {
-    return num;
-  }
-  return String(num).padStart(3, "0");
-};
+const StyPokemonFigure = styled.figure`
+  width: 50%;
+`;

--- a/src/Components/SingleTableItem.js
+++ b/src/Components/SingleTableItem.js
@@ -30,11 +30,8 @@ const StySingleTableItem = styled.article`
   align-items: center;
   width: 150px;
   height: 125px;
-  /* border: 3px solid blue; */
 `;
 
 const StyPokemonFigure = styled.figure`
-  /* width: 50%; */
-  border: 1px solid blue;
   width: 60%;
 `;

--- a/src/Redux/pokemonDisplayOptionSlice.js
+++ b/src/Redux/pokemonDisplayOptionSlice.js
@@ -6,8 +6,6 @@ const TOGGLEPOKEMONDISPLAYOPTION = "TOGGLEPOKEMONDISPLAYOPTION";
 const pokemonDisplayToggleReducer = (state, action) => {
   switch (action.type) {
     case TOGGLEPOKEMONDISPLAYOPTION: {
-      // console.log("state:", state);
-      console.log("action.payload:", action.payload);
       return {
         isDisplayPokemon: action.payload,
       };

--- a/src/Redux/pokemonDisplayOptionSlice.js
+++ b/src/Redux/pokemonDisplayOptionSlice.js
@@ -8,7 +8,9 @@ const pokemonDisplayToggleReducer = (state, action) => {
     case TOGGLEPOKEMONDISPLAYOPTION: {
       return {
         ...state,
-        displayPokemon: !action.payload,
+        displayPokemon: {
+          isDisplayPokemon: action.payload,
+        },
       };
     }
     default:

--- a/src/Redux/pokemonDisplayOptionSlice.js
+++ b/src/Redux/pokemonDisplayOptionSlice.js
@@ -1,5 +1,8 @@
 const TOGGLEPOKEMONDISPLAYOPTION = "TOGGLEPOKEMONDISPLAYOPTION";
 
+//The user is able to choose whether to display a Pokemon for each number in the multiplication table
+//This dispatches their choice to the store when the user toggles the option in the form.
+
 const pokemonDisplayToggleReducer = (state, action) => {
   switch (action.type) {
     case TOGGLEPOKEMONDISPLAYOPTION: {

--- a/src/Redux/pokemonDisplayOptionSlice.js
+++ b/src/Redux/pokemonDisplayOptionSlice.js
@@ -1,0 +1,18 @@
+const TOGGLEPOKEMONDISPLAYOPTION = "TOGGLEPOKEMONDISPLAYOPTION";
+
+const pokemonDisplayToggleReducer = (state, action) => {
+  switch (action.type) {
+    case TOGGLEPOKEMONDISPLAYOPTION: {
+      return {
+        ...state,
+        displayPokemon: !state.displayPokemon,
+      };
+    }
+    default:
+      return {
+        ...state,
+      };
+  }
+};
+
+export default pokemonDisplayToggleReducer;

--- a/src/Redux/pokemonDisplayOptionSlice.js
+++ b/src/Redux/pokemonDisplayOptionSlice.js
@@ -8,7 +8,7 @@ const pokemonDisplayToggleReducer = (state, action) => {
     case TOGGLEPOKEMONDISPLAYOPTION: {
       return {
         ...state,
-        displayPokemon: !state.displayPokemon,
+        displayPokemon: !action.payload,
       };
     }
     default:

--- a/src/Redux/pokemonDisplayOptionSlice.js
+++ b/src/Redux/pokemonDisplayOptionSlice.js
@@ -6,11 +6,10 @@ const TOGGLEPOKEMONDISPLAYOPTION = "TOGGLEPOKEMONDISPLAYOPTION";
 const pokemonDisplayToggleReducer = (state, action) => {
   switch (action.type) {
     case TOGGLEPOKEMONDISPLAYOPTION: {
+      // console.log("state:", state);
+      console.log("action.payload:", action.payload);
       return {
-        ...state,
-        displayPokemon: {
-          isDisplayPokemon: action.payload,
-        },
+        isDisplayPokemon: action.payload,
       };
     }
     default:

--- a/src/Redux/reducer.js
+++ b/src/Redux/reducer.js
@@ -7,6 +7,7 @@ import pokemonDisplayToggleReducer from "./pokemonDisplayOptionSlice";
 
 const rootReducer = combineReducers({
   tableValues: tableValuesReducer,
+  displayPokemon: pokemonDisplayToggleReducer,
 });
 
 export default rootReducer;

--- a/src/Redux/reducer.js
+++ b/src/Redux/reducer.js
@@ -3,6 +3,7 @@
 
 import { combineReducers } from "@reduxjs/toolkit";
 import tableValuesReducer from "./tableValuesSlice";
+import pokemonDisplayToggleReducer from "./pokemonDisplayOptionSlice";
 
 const rootReducer = combineReducers({
   tableValues: tableValuesReducer,

--- a/src/Redux/store.js
+++ b/src/Redux/store.js
@@ -22,14 +22,12 @@ import rootReducer from "./reducer";
 
 //Initial state is self explanatory: The default values that I want state to have.
 //This will grow as the app grows.
-const initialState = {
-  tableValues: {
-    multiplier: 10,
-    limit: 30,
-  },
-  displayPokemon: false,
-};
 
-const store = createStore(rootReducer, initialState);
+// const store = createStore(rootReducer, initialState);
 
-export default store;
+// export default store;
+
+export default function configureStore(initialState) {
+  const store = createStore(rootReducer, initialState);
+  return store;
+}

--- a/src/Redux/store.js
+++ b/src/Redux/store.js
@@ -27,6 +27,7 @@ const initialState = {
     multiplier: 10,
     limit: 30,
   },
+  displayPokemon: false,
 };
 
 const store = createStore(rootReducer, initialState);

--- a/src/Redux/store.js
+++ b/src/Redux/store.js
@@ -23,10 +23,6 @@ import rootReducer from "./reducer";
 //Initial state is self explanatory: The default values that I want state to have.
 //This will grow as the app grows.
 
-// const store = createStore(rootReducer, initialState);
-
-// export default store;
-
 export default function configureStore(initialState) {
   const store = createStore(rootReducer, initialState);
   return store;

--- a/src/Redux/tableValuesSlice.js
+++ b/src/Redux/tableValuesSlice.js
@@ -10,9 +10,9 @@ const NEWMULTIPLIERANDLIMIT = "NEWMULTIPLIERANDLIMIT";
 const tableValuesReducer = (state, action) => {
   switch (action.type) {
     case NEWMULTIPLIERANDLIMIT: {
+      console.log("action.payload:", action.payload);
       //things might need to change here based on the keys in rootReducer object, not totally sure yet
       return {
-        ...state,
         multiplier: action.payload.multiplier,
         limit: action.payload.limit,
       };

--- a/src/Redux/tableValuesSlice.js
+++ b/src/Redux/tableValuesSlice.js
@@ -10,7 +10,7 @@ const NEWMULTIPLIERANDLIMIT = "NEWMULTIPLIERANDLIMIT";
 const tableValuesReducer = (state, action) => {
   switch (action.type) {
     case NEWMULTIPLIERANDLIMIT: {
-      console.log("action.payload:", action.payload);
+      // console.log("action.payload:", action.payload);
       //things might need to change here based on the keys in rootReducer object, not totally sure yet
       return {
         multiplier: action.payload.multiplier,

--- a/src/Redux/tableValuesSlice.js
+++ b/src/Redux/tableValuesSlice.js
@@ -10,7 +10,6 @@ const NEWMULTIPLIERANDLIMIT = "NEWMULTIPLIERANDLIMIT";
 const tableValuesReducer = (state, action) => {
   switch (action.type) {
     case NEWMULTIPLIERANDLIMIT: {
-      // console.log("action.payload:", action.payload);
       //things might need to change here based on the keys in rootReducer object, not totally sure yet
       return {
         multiplier: action.payload.multiplier,

--- a/src/Tests/App.test.js
+++ b/src/Tests/App.test.js
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render } from "@testing-library/react";
 import App from "../App";
 import store from "../Redux/store";
 import { Provider } from "react-redux";

--- a/src/Tests/App.test.js
+++ b/src/Tests/App.test.js
@@ -3,8 +3,6 @@ import App from "../App";
 import store from "../Redux/store";
 import { Provider } from "react-redux";
 
-console.log("store:", store);
-
 test("[1] Sanity checks", () => {
   const twoPlusTwo = 2 + 2;
   expect(twoPlusTwo).toBe(4);

--- a/src/index.js
+++ b/src/index.js
@@ -19,7 +19,7 @@ const initialState = {
 
 const store = configureStore(initialState);
 
-console.log("store:", store);
+// console.log("store:", store);
 
 ReactDOM.render(
   <Provider store={store}>

--- a/src/index.js
+++ b/src/index.js
@@ -19,8 +19,6 @@ const initialState = {
 
 const store = configureStore(initialState);
 
-// console.log("store:", store);
-
 ReactDOM.render(
   <Provider store={store}>
     <App />

--- a/src/index.js
+++ b/src/index.js
@@ -2,9 +2,24 @@ import React from "react";
 import ReactDOM from "react-dom";
 import "./index.css";
 import App from "./App";
-import store from "./Redux/store";
+// import store from "./Redux/store";
+import configureStore from "./Redux/store";
 import { Provider } from "react-redux";
 import reportWebVitals from "./reportWebVitals";
+
+const initialState = {
+  tableValues: {
+    multiplier: 10,
+    limit: 30,
+  },
+  displayPokemon: {
+    isDisplayPokemon: false,
+  },
+};
+
+const store = configureStore(initialState);
+
+console.log("store:", store);
 
 ReactDOM.render(
   <Provider store={store}>


### PR DESCRIPTION
MAIN OBJECTIVE:
Give user the option to toggle a pokemon display
-For each multiplication table number, a small pokemon image will display
-The pokemon will correspond to that number in the Pokedex

NOTE:
 I have accomplished the act of letting the user toggle the Pokemon Display option in redux state. I still need to put in to effect the styling and things to actually toggle the images. Right now the images are hard-coded in the app. The styling and things will come in another PR soon.

Changes:
+Expanded Redux store to have displayPokemon object containing isDisplayPokemon boolean
+Wrote pokemonDisplayOptionSlice with reducer to take in that user preference
+Update DisplayOptionsForm.js to contain checkbox to toggle display
+Expand onSubmit function in DisplayOptionsForm to dispatch changed pokemon Display preference
+Left helpful comments explaining my choices
+Small refactor: Updated MultTableContainer to have a more efficient mapping algorithm


TODO: Will do these in a PR soon.
+Actually update mult table components to take in this display pokemon user preference, and toggle the pokemon images accordingly
+Write unit tests to verify these functionalities work
