### PR TITLE
Display pokemon toggle styling

### DIFF
--- a/src/Components/MultTableContainer.js
+++ b/src/Components/MultTableContainer.js
@@ -24,6 +24,7 @@ const MultTableContainer = (props) => {
             key={index}
             toBeMultiplied={multiplier}
             currentMultiplier={index + 1}
+            isDisplayPokemon={isDisplayPokemon}
           />
         );
       })}

--- a/src/Components/MultTableContainer.js
+++ b/src/Components/MultTableContainer.js
@@ -9,7 +9,6 @@ const MultTableContainer = (props) => {
   const state = useSelector(selectState);
   const { multiplier, limit } = state.tableValues;
   const isDisplayPokemon = state.displayPokemon.isDisplayPokemon;
-  console.log("isDisplayPokemon:", isDisplayPokemon);
 
   //creating an array to map over to generate multiplication table
   //it's just full of zeroes, it could contain anything, doesn't matter. I just can't map over a sparse array,

--- a/src/Components/MultTableContainer.js
+++ b/src/Components/MultTableContainer.js
@@ -8,6 +8,8 @@ const MultTableContainer = (props) => {
   //pulls in global state from Redux store
   const state = useSelector(selectState);
   const { multiplier, limit } = state.tableValues;
+  const isDisplayPokemon = state.displayPokemon.isDisplayPokemon;
+  console.log("isDisplayPokemon:", isDisplayPokemon);
 
   //creating an array to map over to generate multiplication table
   //it's just full of zeroes, it could contain anything, doesn't matter. I just can't map over a sparse array,

--- a/src/Components/SingleTableItem.js
+++ b/src/Components/SingleTableItem.js
@@ -1,7 +1,8 @@
 import styled from "styled-components";
 
 const SingleTableItem = (props) => {
-  const { toBeMultiplied, currentMultiplier } = props;
+  const { toBeMultiplied, currentMultiplier, isDisplayPokemon } = props;
+  console.log("isDisplayPokemon:", isDisplayPokemon);
   const total = toBeMultiplied * currentMultiplier;
 
   return (

--- a/src/Components/SingleTableItem.js
+++ b/src/Components/SingleTableItem.js
@@ -6,7 +6,10 @@ const SingleTableItem = (props) => {
   const total = toBeMultiplied * currentMultiplier;
 
   return (
-    <StySingleTableItem data-testid="single-table-item">
+    <StySingleTableItem
+      data-testid="single-table-item"
+      isDisplayPokemon={isDisplayPokemon}
+    >
       {toBeMultiplied} x {currentMultiplier} = {total}
       {/* contains pokemon img if user has toggled that option */}
       {isDisplayPokemon && (
@@ -34,6 +37,7 @@ const StySingleTableItem = styled.article`
   align-items: center;
   width: 150px;
   height: 125px;
+  /* width: 180px; */
 `;
 
 const StyPokemonFigure = styled.figure`

--- a/src/Components/SingleTableItem.js
+++ b/src/Components/SingleTableItem.js
@@ -36,8 +36,9 @@ const StySingleTableItem = styled.article`
   flex-direction: column;
   align-items: center;
   width: 150px;
-  height: 125px;
-  /* width: 180px; */
+  height: ${(props) => {
+    return props.isDisplayPokemon ? "150px" : "auto";
+  }};
 `;
 
 const StyPokemonFigure = styled.figure`

--- a/src/Components/SingleTableItem.js
+++ b/src/Components/SingleTableItem.js
@@ -2,20 +2,22 @@ import styled from "styled-components";
 
 const SingleTableItem = (props) => {
   const { toBeMultiplied, currentMultiplier, isDisplayPokemon } = props;
-  console.log("isDisplayPokemon:", isDisplayPokemon);
+  // console.log("isDisplayPokemon:", isDisplayPokemon);
   const total = toBeMultiplied * currentMultiplier;
 
   return (
     <StySingleTableItem data-testid="single-table-item">
       {toBeMultiplied} x {currentMultiplier} = {total}
       {/* contains pokemon img if user has toggled that option */}
-      <StyPokemonFigure>
-        <img
-          data-testid="poke-img"
-          src={`https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/${total}.png`}
-          alt="pokemon"
-        />
-      </StyPokemonFigure>
+      {isDisplayPokemon && (
+        <StyPokemonFigure>
+          <img
+            data-testid="poke-img"
+            src={`https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/${total}.png`}
+            alt="pokemon"
+          />
+        </StyPokemonFigure>
+      )}
     </StySingleTableItem>
   );
 };

--- a/src/Components/SingleTableItem.js
+++ b/src/Components/SingleTableItem.js
@@ -42,5 +42,5 @@ const StySingleTableItem = styled.article`
 `;
 
 const StyPokemonFigure = styled.figure`
-  width: 60%;
+  width: 80%;
 `;

--- a/src/Components/SingleTableItem.js
+++ b/src/Components/SingleTableItem.js
@@ -2,7 +2,6 @@ import styled from "styled-components";
 
 const SingleTableItem = (props) => {
   const { toBeMultiplied, currentMultiplier, isDisplayPokemon } = props;
-  // console.log("isDisplayPokemon:", isDisplayPokemon);
   const total = toBeMultiplied * currentMultiplier;
 
   return (

--- a/src/Tests/SingleTableItem.test.js
+++ b/src/Tests/SingleTableItem.test.js
@@ -24,10 +24,14 @@ test("[2] Correct numbers appear in component", () => {
   expect(expectedSolution).toBeVisible();
 });
 
-test("[3] Pokemon image appears on screen", () => {
+test("[3] Pokemon image appears on screen when isDisplayPokemon is true", () => {
   render(
     <Provider store={store}>
-      <SingleTableItem toBeMultiplied={10} currentMultiplier={7} />
+      <SingleTableItem
+        toBeMultiplied={10}
+        currentMultiplier={7}
+        isDisplayPokemon={true}
+      />
     </Provider>
   );
 

--- a/src/Tests/SingleTableItem.test.js
+++ b/src/Tests/SingleTableItem.test.js
@@ -24,8 +24,21 @@ test("[2] Correct numbers appear in component", () => {
   expect(expectedSolution).toBeVisible();
 });
 
-test("[3] Pokemon image appears on screen when isDisplayPokemon is true", () => {
-  render(
+test("[3] Pokemon image toggles based on user preference", async () => {
+  const { rerender } = render(
+    <Provider store={store}>
+      <SingleTableItem
+        toBeMultiplied={10}
+        currentMultiplier={7}
+        isDisplayPokemon={false}
+      />
+    </Provider>
+  );
+
+  const pokemonImg = screen.queryByTestId("poke-img");
+  expect(pokemonImg).not.toBeInTheDocument();
+
+  rerender(
     <Provider store={store}>
       <SingleTableItem
         toBeMultiplied={10}
@@ -35,6 +48,6 @@ test("[3] Pokemon image appears on screen when isDisplayPokemon is true", () => 
     </Provider>
   );
 
-  const pokeImg = screen.getByTestId("poke-img");
-  expect(pokeImg).toBeVisible();
+  const newPokemonImg = screen.queryByTestId("poke-img");
+  expect(newPokemonImg).toBeInTheDocument();
 });


### PR DESCRIPTION
OBJECTIVE (ACCOMPLISHED):
Implement styling for Pokemon Display option
-Based on user preference, the app will display (or not display) a pokemon corresponding to each number in the multiplication table

ACTIONS TAKEN:

MultTableContainer.js:
+Declared isDisplayPokemon boolean
+Pass this boolean down to SingleTableItem.js through props

SingleTableItem.js
+Implement dynamic styling (using Styled Components) to display pokemon image based on isDisplayPokemon boolean
+Make pokemon image wider, from 60% to 80%

TESTING:

SingleTableItem.test.js:
+Added test [3] to make sure that SingleTableItem re-renders with image (or no image) based on changed isDisplayPokemon value