### PR TITLE
Feature/pokemon higher numbers

### DIFF
--- a/src/Components/SingleTableItem.js
+++ b/src/Components/SingleTableItem.js
@@ -2,7 +2,13 @@ import styled from "styled-components";
 
 const SingleTableItem = (props) => {
   const { toBeMultiplied, currentMultiplier, isDisplayPokemon } = props;
+
   const total = toBeMultiplied * currentMultiplier;
+
+  let pokeId = total;
+  if (total > 898) {
+    pokeId = Math.floor(Math.random() * 898);
+  }
 
   return (
     <StySingleTableItem
@@ -15,7 +21,9 @@ const SingleTableItem = (props) => {
         <StyPokemonFigure>
           <img
             data-testid="poke-img"
-            src={`https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/${total}.png`}
+            src={`https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/${
+              pokeId + 1
+            }.png`}
             alt="pokemon"
           />
         </StyPokemonFigure>

--- a/src/Components/SingleTableItem.js
+++ b/src/Components/SingleTableItem.js
@@ -8,6 +8,8 @@ const SingleTableItem = (props) => {
 
   const total = toBeMultiplied * currentMultiplier;
 
+  // pokedex ids max out at 898,
+  // So this generates a random id for numbers over 898
   let pokeId = total;
   if (total > 898) {
     pokeId = Math.floor(Math.random() * 898);

--- a/src/Components/SingleTableItem.js
+++ b/src/Components/SingleTableItem.js
@@ -1,3 +1,6 @@
+// If the user chooses, this component displays an image of the pokemon with pokedex id corresponding to displayed total
+// Pokedex id's only go up to 898, so if the total is higher than that, a random pokedex id will be generated >= 898.
+
 import styled from "styled-components";
 
 const SingleTableItem = (props) => {


### PR DESCRIPTION
GOAL: Make SingleTableItem (STI.js) display pokemon images when total is over 898
-The issue is that pokedex ids max out at 898

ACTIONS:

SingleTableItem.js:
Wrote functionality to generate randomized id if total is over 898
Confirmed all tests still pass, tested app manually as well